### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/fjordllc/interns.png?label=ready&title=Ready)](https://waffle.io/fjordllc/interns)
 # 256 interns
 
 [![Build Status](https://api.travis-ci.org/fjordllc/interns.png?branch=master)](https://travis-ci.org/fjordllc/interns)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/fjordllc/interns

This was requested by a real person (user komagata) on waffle.io, we're not trying to spam you.