### PR TITLE
Hide password in Sign Up form

### DIFF
--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -33,10 +33,10 @@
     = f.text_field :feed_url, class: 'form-control'
   .form-group
     = f.label :password
-    = f.text_field :password, class: 'form-control'
+    = f.password_field :password, class: 'form-control'
   .form-group
     = f.label :password_confirmation
-    = f.text_field :password_confirmation, class: 'form-control'
+    = f.password_field :password_confirmation, class: 'form-control'
   .form-group
     = f.label :purpose, style: 'display: block'
     = f.collection_radio_buttons :purpose_cd, User.purposes.map {|k,v| [v, t("activerecord.enums.user.purposes.#{k}")] }, :first, :last do |b|


### PR DESCRIPTION
@komagata #95 に対応して、サインアップ画面のパスワード入力欄がマスクされるようにしました。
![2015-11-18 17 49 40](https://cloud.githubusercontent.com/assets/10114122/11236414/caa2a13c-8e1c-11e5-945f-aaab929a2a2e.png)
ご確認お願いします。

connencted to #95 