### PR TITLE
日報の検索機能を追加

### DIFF
--- a/app/assets/stylesheets/_base.css.sass
+++ b/app/assets/stylesheets/_base.css.sass
@@ -6,3 +6,20 @@
   &.is-opened-drawer
     overflow: hidden
     right: 280px
+
+.search-form
+  position: relative
+  padding-right: 36px
+  margin-top: 8px
+.search__input-text
+  height: 28px
+  font-size: 14px
+.search__submit
+  position: absolute
+  right: 0
+  top: 0
+  bottom: 0
+  padding: 0 8px
+  background: #1e88e5
+  border-radius: 4px
+  color: white

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -2,6 +2,7 @@ class ReportsController < ApplicationController
   include Rails.application.routes.url_helpers
   include Gravatarify::Helper
   before_action :require_login
+  before_action :set_search_word, only: :index
   before_action :set_reports, only: %w(index show edit update destroy)
   before_action :set_report, only: %w(show)
   before_action :set_my_report, only: %i(edit update destroy)
@@ -68,9 +69,12 @@ class ReportsController < ApplicationController
     )
   end
 
+  def set_search_word
+    @search_word = params[:word]
+  end
+
   def set_reports
-    if params.key?(:word)
-      @search_word = params[:word]
+    if params[:word].present?
       @reports = Report.where('description LIKE ?', "%#{@search_word}%").order(updated_at: :desc, id: :desc)
     else
       @reports = Report.order(updated_at: :desc, id: :desc)

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -69,7 +69,12 @@ class ReportsController < ApplicationController
   end
 
   def set_reports
-    @reports = Report.order(updated_at: :desc, id: :desc)
+    if params.key?(:word)
+      @search_word = params[:word]
+      @reports = Report.where('description LIKE ?', "%#{@search_word}%").order(updated_at: :desc, id: :desc)
+    else
+      @reports = Report.order(updated_at: :desc, id: :desc)
+    end
   end
 
   def set_report

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -75,7 +75,7 @@ class ReportsController < ApplicationController
 
   def set_reports
     if params[:word].present?
-      @reports = Report.where('description LIKE ?', "%#{@search_word}%").order(updated_at: :desc, id: :desc)
+      @reports = Report.where('title LIKE ? or description LIKE ?', "%#{@search_word}%", "%#{@search_word}%").order(updated_at: :desc, id: :desc)
     else
       @reports = Report.order(updated_at: :desc, id: :desc)
     end

--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -5,7 +5,9 @@ nav.global-nav
       .global-nav-item__search-form
         = form_tag reports_url, method: 'get', class: 'search-form' do
           .search-form__text-field-wrapper
-            = text_field_tag 'word', @word, class: 'search__input-text form-text-field' , placeholder: t('search_report')
+            = text_field_tag 'word', @word, class: 'search__input-text form-control' , placeholder: t('search_report')
+            button.search__submit type= 'submit'
+              i.fa.fa-search
       .global-nav-links.is-contents-links
         ul.global-nav-links__items
           - if current_user

--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -2,6 +2,10 @@ nav.global-nav
   .container
     .global-nav__container
       = link_to t('256interns'), root_path, class: 'global-nav__title'
+      .global-nav-item__search-form
+        = form_tag reports_url, method: 'get', class: 'search-form' do
+          .search-form__text-field-wrapper
+            = text_field_tag 'word', @word, class: 'search__input-text form-text-field' , placeholder: t('search_report')
       .global-nav-links.is-contents-links
         ul.global-nav-links__items
           - if current_user

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -22,7 +22,7 @@
           .reports
             .reports-item
               = link_to report, itempro: "url", class: "reports-item__link" do
-                h3.creports-item__title(itemprop="name")= report.title
+                h3.creports-item__title(itemprop="name")= highlight("#{report.title}", "#{@search_word}")
                 = gravatar_tag report.user, size: 44, html: { class: "category-practices-item__user-icon"}
               time.contents-list-meta__updated_at(datetime="#{report.updated_at.to_datetime}" pubdate="pubdate")
                 = l report.updated_at, format: :short

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -27,3 +27,6 @@ header.page-header
                   = link_to t('edit'), edit_report_path(report), class: 'btn btn-primary'
                   = link_to t('copy'), new_report_path(report), class: 'btn btn-success'
                   = link_to t('destroy'), report_path(report), data: { confirm: t('are_you_sure') }, method: :delete, class: 'btn btn-danger'
+            - if @search_word.present?
+              .report__body
+                = highlight("#{report.description}", "#{@search_word}")

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -1,10 +1,19 @@
-- title t('reports')
-header.page-header
-  .container
-    .page-header__container
-      h2.page-header__title
-        = t('reports')
-      = link_to t('new_report'), new_report_path, class: 'btn btn-primary btn-md page-header__button'
+- if @search_word.present?
+  - title t('search_for', text: @search_word)
+  header.page-header
+    .container
+      .page-header__container
+        h2.page-header__title
+          = t('search_for', text: @search_word)
+        = link_to t('new_report'), new_report_path, class: 'btn btn-primary btn-md page-header__button'
+- else
+  - title t('reports')
+  header.page-header
+    .container
+      .page-header__container
+        h2.page-header__title
+          = t('reports')
+        = link_to t('new_report'), new_report_path, class: 'btn btn-primary btn-md page-header__button'
 .page-body
   .container
     - if @reports.nil? == false

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -22,7 +22,7 @@
           .reports
             .reports-item
               = link_to report, itempro: "url", class: "reports-item__link" do
-                h3.creports-item__title(itemprop="name")= highlight("#{report.title}", "#{@search_word}")
+                h3.reports-item__title(itemprop="name")= highlight("#{report.title}", "#{@search_word}")
                 = gravatar_tag report.user, size: 44, html: { class: "category-practices-item__user-icon"}
               time.contents-list-meta__updated_at(datetime="#{report.updated_at.to_datetime}" pubdate="pubdate")
                 = l report.updated_at, format: :short

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -60,7 +60,7 @@ header.page-header
           - @reports.each do |report|
             .reports-item
               = link_to report, itempro: "url", class: "reports-item__link" do
-                h3.creports-item__title(itemprop="name")= report.title
+                h3.reports-item__title(itemprop="name")= report.title
               time.contents-list-meta__updated_at(datetime="#{report.updated_at.to_datetime}" pubdate="pubdate")
                 = l report.updated_at, format: :short
                 - if report.comments.any?

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -438,3 +438,4 @@ ja:
   order: 並び順
   related-reports: 関連した日報
   search_report: 日報検索
+  search_for: " %{text} の検索結果"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -437,3 +437,4 @@ ja:
   action: 操作
   order: 並び順
   related-reports: 関連した日報
+  search_report: 日報検索

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -438,4 +438,4 @@ ja:
   order: 並び順
   related-reports: 関連した日報
   search_report: 日報検索
-  search_for: " %{text} の検索結果"
+  search_for: "'%{text}' の検索結果"


### PR DESCRIPTION
connected #123 

# Todo

- [x] 検索フォームをヘッダーに設置
  - [x] プレイスホルダーに`日報検索`と表示
- [x] 検索ワードが存在する時、検索ワードの存在するレコードのみ取得
- [x] 検索ワードを使った日報の本文を表示
  - [x]  表示される検索ワードをハイライト
  - [x] 取得したレコードを更新日を基準にして直近の日報から表示
- [x] 検索結果画面にて`<検索ワード> の検索結果`と表示
- [x] 検索フォームのデザインをどのようにするべきか@machidaさんに伺う
- [x] 検索範囲に日報のタイトルを含める
  - [x]  表示される検索ワードをハイライト