### PR TITLE
Kaminariを使ってページネーション機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "typhoeus"
 gem "gemoji"
 gem "redcarpet"
 gem "markdown_checkboxes"
+gem 'kaminari'
 
 gem 'sprockets', '>= 3.0.0'
 gem 'sprockets-es6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,9 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     jwt (1.5.2)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -272,6 +275,7 @@ DEPENDENCIES
   gravatarify
   jbuilder
   jquery-rails
+  kaminari
   markdown_checkboxes
   newrelic_rpm
   oulu

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -75,9 +75,9 @@ class ReportsController < ApplicationController
 
   def set_reports
     if params[:word].present?
-      @reports = Report.where('title LIKE ? or description LIKE ?', "%#{@search_word}%", "%#{@search_word}%").order(updated_at: :desc, id: :desc)
+      @reports = Report.where('title LIKE ? or description LIKE ?', "%#{@search_word}%", "%#{@search_word}%").order(updated_at: :desc, id: :desc).page(params[:page]).per(15)
     else
-      @reports = Report.order(updated_at: :desc, id: :desc)
+      @reports = Report.order(updated_at: :desc, id: :desc).page(params[:page]).per(30)
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
 
   def index
     @categories = Category.order("position")
-    @users = User.order(updated_at: :desc)
+    @users = User.order(updated_at: :desc).page(params[:page]).per(15)
     @target = params[:target] || "all"
     @users =
       case @target

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { remote: remote, class: 'page-link' }

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -1,0 +1,6 @@
+- if page.current?
+  li.page-item.active
+    = content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+- else
+  li.page-item
+    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,10 @@
+= paginator.render do
+  nav
+    ul.pagination
+      == first_page_tag unless current_page.first?
+      == prev_page_tag unless current_page.first?
+      - each_page do |page|
+        - if page.left_outer? || page.right_outer? || page.inside_window?
+          == page_tag page
+      == next_page_tag unless current_page.last?
+      == last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -39,3 +39,4 @@
             - if @search_word.present?
               .report__body
                 = highlight("#{report.description}", "#{@search_word}")
+      = paginate @reports

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -11,3 +11,4 @@ header.page-header.is-margin-bottom-0
   .container
     .users
       = render 'user', users: @users
+  = paginate @users

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -318,8 +318,8 @@ ja:
         format: "%{attribute}%{message}"
   views:
     pagination:
-      previous: "« 前ページ"
-      next: "次ページ »"
+      previous: "« 前のページ"
+      next: "次のページ »"
       truncate: ""
       last: "最後のページ"
       first: "最初のページ"


### PR DESCRIPTION
# Todo
- [x] Kaminariの導入
- [x] ページネーションをBootstrap4に対応
- 日報一覧ページ
  - [x] Controllerに取得件数を記述
  - [x] Viewにページネーション機能を描画
- ユーザー一覧ページ
  - [x] Controllerに取得件数を記述
  - [x] Viewにページネーション機能を描画
- [ ] 1ページあたりの取得件数が現状で良いか確認（2016/12/07 現在）
  - 日報一覧画面  【30件】
  - 日報検索画面【15件】
  - ユーザー一覧画面【15件】

connected #139