### PR TITLE
複数ブラウザでログインを永続化

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -3,7 +3,7 @@ class UserSessionsController < ApplicationController
   end
 
   def create
-    @user = login(params[:user][:login_name], params[:user][:password], true)
+    @user = login(params[:user][:login_name], params[:user][:password], params[:remember])
     if @user && !@user.retire?
       save_updated_at(@user)
       redirect_back_or_to :users, notice: t('sign_in_successful')

--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -6,6 +6,9 @@
     .auth-form-item
       = f.label :password, class: 'a-sm-label'
       = f.password_field :password, class: 'a-sm-text-input'
+    .auth-form-item
+      = check_box_tag :remember, params[:remember], true
+      = f.label :remember_me
       .auth-form-item__help.is-text-align-right
         = link_to '', class: 'auth-form-item__help-link' do
           | パスワードを忘れた

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -13,31 +13,21 @@ Rails.application.config.sorcery.configure do |config|
   #
   # config.not_authenticated_action =
 
-
   # When a non logged in user tries to enter a page that requires login, save
   # the URL he wanted to reach, and send him there after login, using 'redirect_back_or_to'.
   # Default: `true`
   #
   # config.save_return_to_url =
 
-
   # Set domain option for cookies; Useful for remember_me submodule.
   # Default: `nil`
   #
   # config.cookie_domain =
 
-  config.user_config do |user|
-    # -- remember_me --
-    # allow the remember_me cookie to settable through AJAX
-    # Default: `true`
-    #
-    # user.remember_me_httponly =
-
-    # How long in seconds the session length will be
-    # Default: `604800`
-    #
-    user.remember_me_for = 256.weeks
-  end
+  # Allow the remember_me cookie to be set through AJAX
+  # Default: `true`
+  #
+  # config.remember_me_httponly =
 
   # -- session timeout --
   # How long in seconds to keep the session alive.
@@ -45,12 +35,10 @@ Rails.application.config.sorcery.configure do |config|
   #
   # config.session_timeout =
 
-
   # Use the last action as the beginning of session timeout.
   # Default: `false`
   #
   # config.session_timeout_from_last_action =
-
 
   # -- http_basic_auth --
   # What realm to display for which controller name. For example {"My App" => "Application"}
@@ -58,39 +46,33 @@ Rails.application.config.sorcery.configure do |config|
   #
   # config.controller_to_realm_map =
 
-
   # -- activity logging --
   # will register the time of last user login, every login.
   # Default: `true`
   #
   # config.register_login_time =
 
-
   # will register the time of last user logout, every logout.
   # Default: `true`
   #
   # config.register_logout_time =
-
 
   # will register the time of last user action, every action.
   # Default: `true`
   #
   # config.register_last_activity_time =
 
-
   # -- external --
-  # What providers are supported by this app, i.e. [:twitter, :facebook, :github, :google, :liveid] .
+  # What providers are supported by this app, i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :slack] .
   # Default: `[]`
   #
   # config.external_providers =
-
 
   # You can change it by your local ca_file. i.e. '/etc/pki/tls/certs/ca-bundle.crt'
   # Path to ca_file. By default use a internal ca-bundle.crt.
   # Default: `'path/to/ca_file'`
   #
   # config.ca_file =
-
 
   # For information about LinkedIn API:
   # - user info fields go to https://developer.linkedin.com/documents/profile-fields
@@ -101,9 +83,19 @@ Rails.application.config.sorcery.configure do |config|
   # config.linkedin.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=linkedin"
   # config.linkedin.user_info_fields = ['first-name', 'last-name']
   # config.linkedin.user_info_mapping = {first_name: "firstName", last_name: "lastName"}
-  # config.linkedin.access_permissions = ['r_basicprofile'] 
+  # config.linkedin.access_permissions = ['r_basicprofile']
   #
-  # Twitter wil not accept any requests nor redirect uri containing localhost,
+  #
+  # For information about XING API:
+  # - user info fields go to https://dev.xing.com/docs/get/users/me
+  #
+  # config.xing.key = ""
+  # config.xing.secret = ""
+  # config.xing.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=xing"
+  # config.xing.user_info_mapping = {first_name: "first_name", last_name: "last_name"}
+  #
+  #
+  # Twitter will not accept any requests nor redirect uri containing localhost,
   # make sure you use 0.0.0.0:3000 to access your app in development
   #
   # config.twitter.key = ""
@@ -115,22 +107,49 @@ Rails.application.config.sorcery.configure do |config|
   # config.facebook.secret = ""
   # config.facebook.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=facebook"
   # config.facebook.user_info_mapping = {:email => "name"}
-  # config.facebook.access_permissions = ["email", "publish_stream"]
+  # config.facebook.access_permissions = ["email", "publish_actions"]
+  # config.facebook.display = "page"
+  # config.facebook.api_version = "v2.2"
   #
   # config.github.key = ""
   # config.github.secret = ""
   # config.github.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=github"
   # config.github.user_info_mapping = {:email => "name"}
   #
+  # config.paypal.key = ""
+  # config.paypal.secret = ""
+  # config.paypal.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=paypal"
+  # config.paypal.user_info_mapping = {:email => "email"}
+  #
+  # config.wechat.key = ""
+  # config.wechat.secret = ""
+  # config.wechat.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=wechat"
+  #
   # config.google.key = ""
   # config.google.secret = ""
   # config.google.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=google"
   # config.google.user_info_mapping = {:email => "email", :username => "name"}
+  # config.google.scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
+  #
+  # For Microsoft Graph, the key will be your App ID, and the secret will be your app password/public key.
+  # The callback URL "can't contain a query string or invalid special characters", see: https://docs.microsoft.com/en-us/azure/active-directory/active-directory-v2-limitations#restrictions-on-redirect-uris
+  # More information at https://graph.microsoft.io/en-us/docs
+  #
+  # config.microsoft.key = ""
+  # config.microsoft.secret = ""
+  # config.microsoft.callback_url = "http://0.0.0.0:3000/oauth/callback/microsoft"
+  # config.microsoft.user_info_mapping = {:email => "userPrincipalName", :username => "displayName"}
+  # config.microsoft.scope = "openid email https://graph.microsoft.com/User.Read"
   #
   # config.vk.key = ""
   # config.vk.secret = ""
   # config.vk.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=vk"
   # config.vk.user_info_mapping = {:login => "domain", :name => "full_name"}
+  #
+  # config.slack.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=slack"
+  # config.slack.key = ''
+  # config.slack.secret = ''
+  # config.slack.user_info_mapping = {email: 'email'}
   #
   # To use liveid in development mode you have to replace mydomain.com with
   # a valid domain even in development. To use a valid domain in development
@@ -141,57 +160,72 @@ Rails.application.config.sorcery.configure do |config|
   # config.liveid.callback_url = "http://mydomain.com:3000/oauth/callback?provider=liveid"
   # config.liveid.user_info_mapping = {:username => "name"}
 
+  # For information about JIRA API:
+  # https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+OAuth+authentication
+  # to obtain the consumer key and the public key you can use the jira-ruby gem https://github.com/sumoheavy/jira-ruby
+  # or run openssl req -x509 -nodes -newkey rsa:1024 -sha1 -keyout rsakey.pem -out rsacert.pem to obtain the public key
+  # Make sure you have configured the application link properly
+
+  # config.jira.key = "1234567"
+  # config.jira.secret = "jiraTest"
+  # config.jira.site = "http://localhost:2990/jira/plugins/servlet/oauth"
+  # config.jira.signature_method =  "RSA-SHA1"
+  # config.jira.private_key_file = "rsakey.pem"
+
+  # For information about Salesforce API:
+  # https://developer.salesforce.com/signup &
+  # https://www.salesforce.com/us/developer/docs/api_rest/
+  # Salesforce callback_url must be https. You can run the following to generate self-signed ssl cert
+  # openssl req -new -newkey rsa:2048 -sha1 -days 365 -nodes -x509 -keyout server.key -out server.crt
+  # Make sure you have configured the application link properly
+  # config.salesforce.key = '123123'
+  # config.salesforce.secret = 'acb123'
+  # config.salesforce.callback_url = "https://127.0.0.1:9292/oauth/callback?provider=salesforce"
+  # config.salesforce.scope = "full"
+  # config.salesforce.user_info_mapping = {:email => "email"}
 
   # --- user config ---
   config.user_config do |user|
     # -- core --
     # specify username attributes, for example: [:username, :email].
-    # Default: `[:username]`
+    # Default: `[:email]`
     #
     user.username_attribute_names = [:login_name]
-
 
     # change *virtual* password attribute, the one which is used until an encrypted one is generated.
     # Default: `:password`
     #
     # user.password_attribute_name =
 
-
     # downcase the username before trying to authenticate, default is false
     # Default: `false`
     #
     # user.downcase_username_before_authenticating =
-
 
     # change default email attribute.
     # Default: `:email`
     #
     # user.email_attribute_name =
 
-
     # change default crypted_password attribute.
     # Default: `:crypted_password`
     #
     # user.crypted_password_attribute_name =
-
 
     # what pattern to use to join the password with the salt
     # Default: `""`
     #
     # user.salt_join_token =
 
-
     # change default salt attribute.
     # Default: `:salt`
     #
     # user.salt_attribute_name =
 
-
     # how many times to apply encryption to the password.
     # Default: `nil`
     #
     # user.stretches =
-
 
     # encryption key used to encrypt reversible encryptions such as AES256.
     # WARNING: If used for users' passwords, changing this key will leave passwords undecryptable!
@@ -199,24 +233,32 @@ Rails.application.config.sorcery.configure do |config|
     #
     # user.encryption_key =
 
-
     # use an external encryption class.
     # Default: `nil`
     #
     # user.custom_encryption_provider =
-
 
     # encryption algorithm name. See 'encryption_algorithm=' for available options.
     # Default: `:bcrypt`
     #
     # user.encryption_algorithm =
 
-
     # make this configuration inheritable for subclasses. Useful for ActiveRecord's STI.
     # Default: `false`
     #
     # user.subclasses_inherit_config =
 
+    # -- remember_me --
+    # How long in seconds the session length will be
+    # Default: `604800`
+    #
+    user.remember_me_for = 256.weeks
+
+    # when true sorcery will persist a single remember me token for all
+    # logins/logouts (supporting remembering on multiple browsers simultaneously).
+    # Default: false
+    #
+    user.remember_me_token_persist_globally = true
 
     # -- user_activation --
     # the attribute name to hold activation state (active/pending).
@@ -224,30 +266,25 @@ Rails.application.config.sorcery.configure do |config|
     #
     # user.activation_state_attribute_name =
 
-
     # the attribute name to hold activation code (sent by email).
     # Default: `:activation_token`
     #
     # user.activation_token_attribute_name =
-
 
     # the attribute name to hold activation code expiration date.
     # Default: `:activation_token_expires_at`
     #
     # user.activation_token_expires_at_attribute_name =
 
-
     # how many seconds before the activation code expires. nil for never expires.
     # Default: `nil`
     #
     # user.activation_token_expiration_period =
 
-
     # your mailer class. Required.
     # Default: `nil`
     #
     # user.user_activation_mailer =
-
 
     # when true sorcery will not automatically
     # email activation details and allow you to
@@ -256,24 +293,26 @@ Rails.application.config.sorcery.configure do |config|
     #
     # user.activation_mailer_disabled =
 
+    # method to send email related
+    # options: `:deliver_later`, `:deliver_now`, `:deliver`
+    # Default: :deliver (Rails version < 4.2) or :deliver_now (Rails version 4.2+)
+    #
+    # user.email_delivery_method =
 
     # activation needed email method on your mailer class.
     # Default: `:activation_needed_email`
     #
     # user.activation_needed_email_method_name =
 
-
     # activation success email method on your mailer class.
     # Default: `:activation_success_email`
     #
     # user.activation_success_email_method_name =
 
-
     # do you want to prevent or allow users that did not activate by email to login?
     # Default: `true`
     #
     # user.prevent_non_active_users_to_login =
-
 
     # -- reset_password --
     # reset password code attribute name.
@@ -281,30 +320,25 @@ Rails.application.config.sorcery.configure do |config|
     #
     # user.reset_password_token_attribute_name =
 
-
     # expires at attribute name.
     # Default: `:reset_password_token_expires_at`
     #
     # user.reset_password_token_expires_at_attribute_name =
-
 
     # when was email sent, used for hammering protection.
     # Default: `:reset_password_email_sent_at`
     #
     # user.reset_password_email_sent_at_attribute_name =
 
-
     # mailer class. Needed.
     # Default: `nil`
     #
     user.reset_password_mailer = UserMailer
 
-
     # reset password email method on your mailer class.
     # Default: `:reset_password_email`
     #
     # user.reset_password_email_method_name =
-
 
     # when true sorcery will not automatically
     # email password reset details and allow you to
@@ -313,18 +347,15 @@ Rails.application.config.sorcery.configure do |config|
     #
     # user.reset_password_mailer_disabled =
 
-
     # how many seconds before the reset request expires. nil for never expires.
     # Default: `nil`
     #
     # user.reset_password_expiration_period =
 
-
-    # hammering protection, how long to wait before allowing another email to be sent.
+    # hammering protection, how long in seconds to wait before allowing another email to be sent.
     # Default: `5 * 60`
     #
     # user.reset_password_time_between_emails =
-
 
     # -- brute_force_protection --
     # Failed logins attribute name.
@@ -332,18 +363,15 @@ Rails.application.config.sorcery.configure do |config|
     #
     # user.failed_logins_count_attribute_name =
 
-
     # This field indicates whether user is banned and when it will be active again.
     # Default: `:lock_expires_at`
     #
     # user.lock_expires_at_attribute_name =
 
-
     # How many failed logins allowed.
     # Default: `50`
     #
     # user.consecutive_login_retries_amount_limit =
-
 
     # How long the user should be banned. in seconds. 0 for permanent.
     # Default: `60 * 60`
@@ -377,24 +405,20 @@ Rails.application.config.sorcery.configure do |config|
     #
     # user.last_login_at_attribute_name =
 
-
     # Last logout attribute name.
     # Default: `:last_logout_at`
     #
     # user.last_logout_at_attribute_name =
-
 
     # Last activity attribute name.
     # Default: `:last_activity_at`
     #
     # user.last_activity_at_attribute_name =
 
-
-    # How long since last activity is he user defined logged out?
+    # How long since last activity is the user defined logged out?
     # Default: `10 * 60`
     #
     # user.activity_timeout =
-
 
     # -- external --
     # Class which holds the various external provider data for this user.
@@ -402,18 +426,15 @@ Rails.application.config.sorcery.configure do |config|
     #
     # user.authentications_class =
 
-
     # User's identifier in authentications class.
     # Default: `:user_id`
     #
     # user.authentications_user_id_attribute_name =
 
-
     # Provider's identifier in authentications class.
     # Default: `:provider`
     #
     # user.provider_attribute_name =
-
 
     # User's external unique identifier in authentications class.
     # Default: `:uid`


### PR DESCRIPTION
## Todo
- [x] ログイン画面にチェックボックスを作成
- [x] sorceryの初期設定ファイル`initializers/sorcery.rb`の記述を変更
  - [x] `config.user_config do |user|` の重複を修正
- [x] #178 のバグが修正されたことを確認
- [x] 複数ブラウザを使用した際にもログインが永続化出来ているか確認

## ログイン永続化が機能していなかった原因
* `initializers/sorcery.rb`の`config.user_config do |user|`が重複して存在していた
* １つの目の`config.user_config do |user|`内の設定は反映されない

## メモ
テストに関して
http://qiita.com/pepepki/items/93b7dced94dbd8ef5c70

connect #178 #179 