### PR TITLE
minitest gem は5.10.2以外を採用する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development, :test do
   gem "pry-byebug"
   gem "simple_seed"
   gem "byebug", platform: :mri
+  gem 'minitest', '~> 5.10', '!= 5.10.2'
 end
 
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.10.2)
+    minitest (5.10.1)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -300,6 +300,7 @@ DEPENDENCIES
   letter_opener_web
   listen (~> 3.0.5)
   markdown_checkboxes
+  minitest (~> 5.10, != 5.10.2)
   newrelic_rpm
   oulu
   pg


### PR DESCRIPTION
## ToDo
- [x] 採用する `minitest` gem が`5.10.2`以外となるように変更する

## 変更する理由
`minitest` gem `5.10.2`にあるバグでテストが通らない

## 参考URL

### バグの詳細
[ruby on rails - minitest_plugin.rb:9 getting wrong number of arguments - Stack Overflow](https://stackoverflow.com/questions/43886586/minitest-plugin-rb9-getting-wrong-number-of-arguments)

### 修正の方向性について
#184

connect #180 