### PR TITLE
require_loginを追加

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,6 +1,4 @@
 class FeedsController < ApplicationController
-  before_action :require_login
-
   def index
     urls = User.pluck(:feed_url).reject { |f| f.blank? }
     hydra = Typhoeus::Hydra.new

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,4 +1,6 @@
 class FeedsController < ApplicationController
+  before_action :require_login
+
   def index
     urls = User.pluck(:feed_url).reject { |f| f.blank? }
     hydra = Typhoeus::Hydra.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   include Gravatarify::Helper
-  before_action :require_login, only: %w[edit update destroy]
+  before_action :require_login
   before_action :set_user, only: %w[show]
   before_action :set_reports, only: %w[show]
   http_basic_authenticate_with name: "intern", password: ENV["INTERN_PASSWORD"] || "test", only: %i(new create)

--- a/test/integration/require_login_test.rb
+++ b/test/integration/require_login_test.rb
@@ -8,12 +8,6 @@ class RequireLoginTest < ActionDispatch::IntegrationTest
     assert_equal 'ログインしてください', flash[:alert]
   end
 
-  test 'feeds_path' do
-    get '/feeds'
-    assert_redirected_to '/login'
-    assert_equal 'ログインしてください', flash[:alert]
-  end
-
   test 'questions_path' do
     get '/questions'
     assert_redirected_to '/login'

--- a/test/integration/require_login_test.rb
+++ b/test/integration/require_login_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class RequireLoginTest < ActionDispatch::IntegrationTest
+
+  test 'users_path' do
+    get '/users'
+    assert_redirected_to '/login'
+    assert_equal 'ログインしてください', flash[:alert]
+  end
+
+  test 'feeds_path' do
+    get '/feeds'
+    assert_redirected_to '/login'
+    assert_equal 'ログインしてください', flash[:alert]
+  end
+
+  test 'questions_path' do
+    get '/questions'
+    assert_redirected_to '/login'
+    assert_equal 'ログインしてください', flash[:alert]
+  end
+
+  test 'practices_path' do
+    get '/practices'
+    assert_redirected_to '/login'
+    assert_equal 'ログインしてください', flash[:alert]
+  end
+
+  test 'reports_path' do
+    get '/reports'
+    assert_redirected_to '/login'
+    assert_equal 'ログインしてください', flash[:alert]
+  end
+
+  test 'pages_path' do
+    get '/pages'
+    assert_redirected_to '/login'
+    assert_equal 'ログインしてください', flash[:alert]
+  end
+end


### PR DESCRIPTION
## ToDo

### controllerにrequire_loginを記述

- [x] users_controller
~~feeds_controller~~RSSリーダーが読める必要があるため除外
- [x] 上記以外に`require_login`が必要な箇所がないか確認

### テストコードを記述
- ログインせずにページにアクセスした際`/login`へリダイレクトが行われているか
  - [x] `/users`
~~/feeds~~RSSリーダーが読める必要があるため除外

## 既にrequire_loginがされているページ
* questions
* practices
* reports
* pages

## その他
> 以前は就職先の人に見せるためにユーザーとか隠してましたが、トップやお問合せ以外はログイン必須でいいとおもいます。

https://github.com/fjordllc/interns/pull/193#pullrequestreview-45889635

connected  #197 