### PR TITLE
日報の確認漏れの問題をハンコで分かりやすくする。

### DIFF
--- a/app/assets/stylesheets/blocks/report/_stamp.sass
+++ b/app/assets/stylesheets/blocks/report/_stamp.sass
@@ -19,3 +19,18 @@
   &.is-created-at
     +size(100% 36%)
     +border(vertical, solid .0625rem $stamp-color)
+
+.stamp-small
+  border: double .1875rem $stamp-color
+  border-radius: .20rem
+  +size(3rem 1.3rem)
+  color: $stamp-color
+  font-size: .5%
+  font-weight: bold
+  font-style: normal
+  +position(absolute, right 3%)
+  &.stamp__content
+    display: flex
+    align-items: center
+    justify-content: center
+    +size(100% 32%)

--- a/app/views/reports/_recent_reports.slim
+++ b/app/views/reports/_recent_reports.slim
@@ -3,5 +3,9 @@
     = gravatar_tag report.user, size: 88, html: { class: "recent-reports-item__user-icon" }
     h3.recent-reports-item__title
       = report.title
+      - if report.checks.present?
+        i.stamp-small
+          .stamp__content
+            | 確認済
     time.recent-reports-item__date
       = l report.updated_at, format: :date_default

--- a/app/views/reports/_report_list_item.html.slim
+++ b/app/views/reports/_report_list_item.html.slim
@@ -29,3 +29,10 @@
           .report-list-item-meta__comment-count-value
             - report.checks.each do |check|
               = gravatar_tag check.user, size: 20, html: { class: "report-list-item__checked-author-icon" }
+        .stamp.stamp-approve
+          h2.stamp__content.is-title
+            | 確認済
+          time.stamp__content.is-created-at
+            = report.checks.last.created_at.strftime('%Y/%m/%d')
+          .stamp__content.is-user-name
+            = report.checks.last.user.login_name

--- a/test/integration/check_report_test.rb
+++ b/test/integration/check_report_test.rb
@@ -15,7 +15,7 @@ class CheckReportTest < ActionDispatch::IntegrationTest
     assert_not has_button? "日報を確認する"
   end
 
-  test "Success Repost Checking" do
+  test "Success Report Checking" do
     visit "/login"
     within("#sign-in-form") do
       fill_in("user[login_name]", with: "machida")
@@ -30,6 +30,8 @@ class CheckReportTest < ActionDispatch::IntegrationTest
     click_button "日報を確認する"
     assert_not has_button? "日報を確認する"
     assert_text "この日報を確認しました。"
+    visit reports_path
+    assert_text "確認済"
   end
 
   test "non button in current_user report" do


### PR DESCRIPTION
issue `日報が確認済みかどうかしりたい #251`
issue `日報一覧で確認済みかどうかしりたい #244`
の実装もしてみました。😊👍

右側のナビゲーションにはハンコは大きすぎたので、小さなハンコにしました。
ご確認頂ければと存じます🙏

[![https://gyazo.com/3379449546a719f89693f2296bc902d6](https://i.gyazo.com/3379449546a719f89693f2296bc902d6.png)](https://gyazo.com/3379449546a719f89693f2296bc902d6)

Connect to #251 
Connect to #244 