### PR TITLE
Fix N+1 problem in recent reports

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,6 +1,6 @@
 module ReportsHelper
   def recent_reports
-    @reports = Report.order(updated_at: :desc, id: :desc).limit(15)
+    @recent_reports ||= Report.eager_load(:user, :checks).order(updated_at: :desc, id: :desc).limit(15)
   end
 
   def admin_can_check_it?

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,4 +1,4 @@
-- content_for(:page_classes, 'no-header' 'no-footer' 'no-recent-reports')
+- content_for(:page_classes, 'no-header no-footer no-recent-reports')
 
 .auth-form.is-sign-up
   header.auth-form__header

--- a/app/views/contacts/new.html.slim
+++ b/app/views/contacts/new.html.slim
@@ -1,4 +1,4 @@
-- content_for(:page_classes, 'no-header' 'no-footer' 'no-recent-reports' 'no-global-nav')
+- content_for(:page_classes, 'no-header no-footer no-recent-reports no-global-nav')
 
 .auth-form.is-contact
   header.auth-form__header

--- a/app/views/home/welcome.html.slim
+++ b/app/views/home/welcome.html.slim
@@ -1,4 +1,4 @@
-- content_for(:page_classes, 'no-header' 'no-recent-reports' 'no-global-nav')
+- content_for(:page_classes, 'no-header no-recent-reports no-global-nav')
 - content_for(:import_javascript) do
   = javascript_include_tag "https://sdk.form.run/js/v2/formrun.js"
 

--- a/app/views/layouts/admin.html.slim
+++ b/app/views/layouts/admin.html.slim
@@ -12,23 +12,19 @@ html.is-admin lang="ja"
     = javascript_include_tag 'application'
     = javascript_include_tag 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js', integrity: 'sha512-K1qjQ+NcF2TYO/eI3M6v8EiNYZfA95pQumfvcVrTHtwQVDG+aHRqLi/ETn2uB+1JqwYqVG3LIvdm9lj6imS/pQ==', crossorigin: 'anonymous'
     = csrf_meta_tags
-    javascript:
-    - if head_last = yield(:head_last)
-      = head_last
-  body class="#{body_class} #{yield(:page_classes)}"
-    - unless yield(:page_classes).include?('no-global-nav')
-      = render 'global_nav'
+    = content_for(:head_last) if content_for?(:head_last)
+  - page_classes = content_for(:page_classes).to_s
+  body class="#{body_class} #{page_classes}"
+    - if page_classes.exclude?("no-global-nav")
+      = render "global_nav"
     .wrapper.js-open-drawer-wrapper
-      - unless yield(:page_classes).include?('no-header')
-        = render 'header'
-      = render 'alert'
+      - if page_classes.exclude?("no-header")
+        = render "header"
+      = render "alert"
       main.page
         = yield
-    - unless yield(:page_classes).include?('no-recent-reports')
-      - recent_reports
-      - if @reports.present?
-        .recent-reports
-          .recent-reports__items
-            - @reports.each do |report|
-              = render 'reports/recent_reports', report: report
-    = render('to_top')
+    - if page_classes.exclude?("no-recent-reports") && recent_reports.present?
+      .recent-reports
+        .recent-reports__items
+          = render partial: "reports/recent_reports", collection: recent_reports, as: :report
+    = render("to_top")

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,27 +10,20 @@ html.is-application lang="ja"
     = javascript_include_tag 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js', integrity: 'sha512-K1qjQ+NcF2TYO/eI3M6v8EiNYZfA95pQumfvcVrTHtwQVDG+aHRqLi/ETn2uB+1JqwYqVG3LIvdm9lj6imS/pQ==', crossorigin: 'anonymous'
     = javascript_pack_tag "application"
     = csrf_meta_tags
-    = yield(:import_javascript)
-    javascript:
-    - if head_last = yield(:head_last)
-      = head_last
-  body(class="#{body_class} #{yield(:page_classes)}" id ="body")
-    - if current_user
-      - unless yield(:page_classes).include?('no-global-nav')
-        = render 'global_nav'
+    = content_for(:import_javascript)
+    = content_for(:head_last) if content_for?(:head_last)
+  - page_classes = content_for(:page_classes).to_s
+  body#body class="#{body_class} #{page_classes}"
+    - if current_user && page_classes.exclude?("no-global-nav")
+        = render "global_nav"
     .wrapper.js-open-drawer-wrapper
-      - if current_user
-        - unless yield(:page_classes).include?('no-header')
-          = render 'header'
-      = render 'alert'
+      - if current_user && page_classes.exclude?("no-header")
+        = render "header"
+      = render "alert"
       main.page
         = yield
-    - if current_user.present?
-      - unless yield(:page_classes).include?('no-recent-reports')
-        - recent_reports
-        - if @reports.present?
-          .recent-reports
-            .recent-reports__items
-              - @reports.each do |report|
-                = render 'reports/recent_reports', report: report
-    = render('to_top')
+    - if current_user && page_classes.exclude?("no-recent-reports") && recent_reports.present?
+      .recent-reports
+        .recent-reports__items
+          = render partial: "reports/recent_reports", collection: recent_reports, as: :report
+    = render("to_top")

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,4 +1,4 @@
-- content_for(:page_classes, 'no-header' 'no-footer' 'no-recent-reports' 'no-global-nav')
+- content_for(:page_classes, 'no-header no-footer no-recent-reports no-global-nav')
 
 = image_tag('logo-colored.svg', class: 'auth-form-logo-image')
 

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,4 +1,4 @@
-- content_for(:page_classes, 'no-header' 'no-footer' 'no-recent-reports')
+- content_for(:page_classes, 'no-header no-footer no-recent-reports')
 
 .auth-form.is-sign-up
   header.auth-form__header

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,4 +1,4 @@
-- content_for(:page_classes, 'no-header' 'no-footer' 'no-recent-reports' 'no-global-nav')
+- content_for(:page_classes, 'no-header no-footer no-recent-reports no-global-nav')
 
 .auth-form.is-sign-up
   header.auth-form__header


### PR DESCRIPTION
- [x] Fix N+1 problem in recent reports (`layout/application` and `layout/admin`)

---

#### Before

![before](https://user-images.githubusercontent.com/26753/32645714-0e5b9a52-c62c-11e7-8b29-6009fe99edf4.png)

---

#### After

![after](https://user-images.githubusercontent.com/26753/32645715-0e7d7d98-c62c-11e7-8130-a60312d754ed.png)

---

- [x] Fix `page_classes`. There were weird class names in some views.

```
# Before
<body class="user_sessions user_sessions-new no-headerno-footerno-recent-reportsno-global-nav" id="body">

# After
<body class="user_sessions user_sessions-new no-header no-footer no-recent-reports no-global-nav" id="body">
```