### PR TITLE
Set categories when report was created or updated

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -14,7 +14,7 @@ class ReportsController < ApplicationController
   before_action :set_footprints, only: %w(show)
   before_action :set_footprint, only: %w(show)
   before_action :set_user, only: :show
-  before_action :set_categories, only: %w(new edit)
+  before_action :set_categories, only: %w(new create edit update)
 
   def index
   end


### PR DESCRIPTION
When there is a validation error in a report, it will raise `NoMethodError`. Because `set_categories` is only called by `new` and `edit` actions.
This PR fixes `set_categories` to call `create` and `update` actions too.

#### Before

![before](https://user-images.githubusercontent.com/26753/32815227-43ef5ac8-c9f6-11e7-9d16-2f57322ee0a9.png)

#### After

![after](https://user-images.githubusercontent.com/26753/32815229-47f38860-c9f6-11e7-8240-97d9405c22c4.png)
