### PR TITLE
Fix copying report

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -127,7 +127,7 @@ class ReportsController < ApplicationController
     end
 
     def set_categories
-      @categories = Category.order('position')
+      @categories = Category.eager_load(:practices).where.not(practices: { id: nil }).order('categories.position ASC, practices.position ASC')
     end
 
     def notify_to_slack(report)

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -26,17 +26,13 @@ class ReportsController < ApplicationController
   end
 
   def new
-    @report = Report.new
-    if params[:format].present?
-      @report_copy_flag = true
-      @report = Report.find_by(id: params[:format])
-      @report_title = @report.title
-      @report_description = @report.description
-      @report = Report.new
+    if params[:id].present?
+      report = current_user.reports.find(params[:id])
+      @report = report.dup
+      @report.practices = report.practices
     else
-      @report_flag = true
-      @report_date = Time.current
-      @user_name = current_user.login_name
+      title = "#{Report.model_name.human}/#{Time.current.strftime("%Y/%m/%d/")}#{current_user.login_name}:"
+      @report = current_user.reports.build(title: title)
     end
   end
 

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -12,7 +12,8 @@
                 - category.practices.each do |practice|
                   label.select-practices__label
                     = check_box_tag "report[practice_ids][]", practice.id, @report.practices.include?(practice), id: "product_practice_ids_#{practice.id}", class: "select-practices__input"
-                    = practice.title
+                    => "[#{category.name}]"
+                    span.select-practices__label-title= practice.title
 
           .form-item
             = f.label :title, class: 'a-label'

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -9,11 +9,10 @@
 
             .select-practices
               - categories.each do |category|
-                - if category.practices.present?
-                  - category.practices.each do |practice|
-                    label.select-practices__label
-                      = check_box_tag "report[practice_ids][]", practice.id, @report.practices.include?(practice), id: "product_practice_ids_#{practice.id}", class: "select-practices__input"
-                      = practice.title
+                - category.practices.each do |practice|
+                  label.select-practices__label
+                    = check_box_tag "report[practice_ids][]", practice.id, @report.practices.include?(practice), id: "product_practice_ids_#{practice.id}", class: "select-practices__input"
+                    = practice.title
 
           .form-item
             = f.label :title, class: 'a-label'

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -17,21 +17,13 @@
 
           .form-item
             = f.label :title, class: 'a-label'
-            - if @report_flag == true
-              = f.text_field :title, class: 'a-text-input js-warning-form', value: '日報/' << @report_date.strftime("%Y/%m/%d/") << @user_name << ':'
-            - elsif @report_copy_flag == true
-              = f.text_field :title, class: 'a-text-input js-warning-form', value: @report_title
-            - else
-              = f.text_field :title, class: 'a-text-input js-warning-form'
+            = f.text_field :title, class: 'a-text-input js-warning-form'
 
     .form-item
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-label'
-          - if @report_copy_flag == true
-            = f.text_area :description, class: "a-textarea js-warning-form markdown-form__text-area js-markdown", data: { "preview": ".js-preview" }, value: @report_description
-          - else
-            = f.text_area :description, class: "a-textarea js-warning-form markdown-form__text-area js-markdown", data: { "preview": ".js-preview" }
+          = f.text_area :description, class: "a-textarea js-warning-form markdown-form__text-area js-markdown", data: { "preview": ".js-preview" }
         .col-md-6.col-xs-12
           .a-label
             | プレビュー

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -34,7 +34,7 @@
                 = link_to edit_report_path(report), class: 'report__actions-item-link is-success' do
                   i.fa.fa-pencil
               li.report__actions-item
-                = link_to new_report_path(report), class: 'report__actions-item-link is-success' do
+                = link_to new_report_path(id: report), class: 'report__actions-item-link is-success' do
                   i.fa.fa-files-o
               li.report__actions-item
                 = link_to report_path(report), data: { confirm: t('are_you_sure') }, method: :delete, class: 'report__actions-item-link is-danger' do

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -15,7 +15,6 @@ header.page-header
     .report-comments-container
       h2.report-comments-container__title
         = t('comments')
-        - @comments.any?
         span.report-comments-container__title-count
           = @comments.count
       .report-comments

--- a/test/integration/reports_test.rb
+++ b/test/integration/reports_test.rb
@@ -11,7 +11,7 @@ class ReportsTest < ActionDispatch::IntegrationTest
 
     click_link '日報'
     click_link '日報の新規作成'
-    report_practices = page.all('.select-practices__label')
+    report_practices = page.all('.select-practices__label-title')
 
     report_practices.each_with_index do|practice, i|
       assert_equal practice.text, practices[i].find('.category-practices-item__title-link').text
@@ -24,7 +24,7 @@ class ReportsTest < ActionDispatch::IntegrationTest
 
     find('.global-nav-current-user__link').click
     page.all('.user-reports-item-actions__item-link').first.click
-    report_practices = page.all('.select-practices__label')
+    report_practices = page.all('.select-practices__label-title')
 
     report_practices.each_with_index do|practice, i|
       assert_equal practice.text, practices[i].find('.category-practices-item__title-link').text


### PR DESCRIPTION
There is a weird format like `/reports/new.1017786038` when I start writing a new report from a previous one. This PR replaces it with `/reports/new?id=1017786038`.

- [x] Replaced `/reports/new.XXXXX` with `/reports/new?id=XXXXX`
- [x] Copied practices from a previous report
- [x] Fixed N+1 problem in categories of report
- [x] Show a category name with a practice title

#### Before

![before](https://user-images.githubusercontent.com/26753/32868574-51b01560-cab6-11e7-9e1d-e1297a72a1b2.png)

#### After

![after](https://user-images.githubusercontent.com/26753/32868575-51d16b02-cab6-11e7-98cd-afa426722f2b.png)