### PR TITLE
Fix listing reports

### DIFF
--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -16,7 +16,7 @@ header.header
         ul.header-links__items
           li
             = form_tag reports_url, method: 'get', class: 'header-search' do
-              = text_field_tag 'word', @word, class: 'a-xs-text-input header-search__text-input', placeholder: t('search_report')
+              = text_field_tag 'word', params[:word], class: 'a-xs-text-input header-search__text-input', placeholder: t('search_report')
               button.is-button-standard-sm-secondary.is-icon.header-search__submit(type= 'submit')
                 i.fa.fa-search
           li.header-links__item(class="#{current_user.notifications.unreads.count > 0 ? "js-drop-down has-count" : "has-no-count"}")

--- a/app/views/practices/_reports.slim
+++ b/app/views/practices/_reports.slim
@@ -2,11 +2,11 @@
   h2.user-reports__title
     = t('related-reports')
   .user-reports__items
-    - @practice.reports.each do |report|
-      .user-reports-item(class= "#{current_user.id == report.user_id ? 'is-mine' : ''}")
+    - reports.each do |report|
+      .user-reports-item(class= "#{current_user == report.user ? 'is-mine' : ''}")
         = link_to report, class: 'user-reports-item__link has-user-icon' do
           = gravatar_tag report.user, size: 64, html: {class: 'user-reports-item__user-icon'}
-          h3.user-reports-item__title itemprop="name" 
+          h3.user-reports-item__title itemprop="name"
             = report.title
           time.user-reports-item__updated-at(datetime="#{report.updated_at.to_datetime}" pubdate="pubdate")
             = l report.updated_at, format: :semi_long
@@ -15,17 +15,13 @@
               .user-reports-item__comment-count-label
                 i.fa.fa-comment-o
               .user-reports-item__comment-count-value
-                = report.comments.count
-        .user-reports-item-actions
-          ul.user-reports-item-actions__items
-            li.user-reports-item-actions__item
-              = link_to edit_report_path(report), class: 'user-reports-item-actions__item-link' do
-                i.fa.fa-pencil
-            li.user-reports-item-actions__item
-              = link_to report_path(report), data: { confirm: t('are_you_sure') }, method: :delete, class: 'user-reports-item-actions__item-link' do
-                i.fa.fa-trash-o
-  .page-actions
-    ul.page-actions__items
-      li.page-actions__item
-        = link_to edit_practice_path(@practice), class: 'is-button-standard-md-secondary' do
-          | 全てを見る
+                = report.comments.size
+        - if report.user == current_user
+          .user-reports-item-actions
+            ul.user-reports-item-actions__items
+              li.user-reports-item-actions__item
+                = link_to edit_report_path(report), class: 'user-reports-item-actions__item-link' do
+                  i.fa.fa-pencil
+              li.user-reports-item-actions__item
+                = link_to report_path(report), data: { confirm: t('are_you_sure') }, method: :delete, class: 'user-reports-item-actions__item-link' do
+                  i.fa.fa-trash-o

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -53,7 +53,7 @@ header.page-header
       // TODO 関連する質問を表示
       //= render 'temp_questions'
       - if @practice.reports.any?
-        = render 'reports'
+        = render 'reports', reports: @practice.reports.eager_load(:user, :comments).order(updated_at: :desc)
 
     .col-xs-12
       .interns-icons

--- a/app/views/reports/_report_list_item.html.slim
+++ b/app/views/reports/_report_list_item.html.slim
@@ -5,14 +5,15 @@
     header.report-list-item__header
       h2.report-list-item__title(itemprop="name")
         = link_to report, itempro: "url", class: "report-list-item__title-link" do
-          = report.title
-      .report-list-item__actions
-        = link_to edit_report_path(report), class: 'report-list-item__actions-link' do
-          i.fa.fa-pencil
-        = link_to new_report_path(report), class: 'report-list-item__actions-link' do
-          i.fa.fa-files-o
-        = link_to report_path(report), data: { confirm: t('are_you_sure') }, method: :delete, class: 'report-list-item__actions-link' do
-          i.fa.fa-trash-o
+          = highlight(report.title, search_words)
+      - if current_user == report.user
+        .report-list-item__actions
+          = link_to edit_report_path(report), class: 'report-list-item__actions-link' do
+            i.fa.fa-pencil
+          = link_to new_report_path(id: report), class: 'report-list-item__actions-link' do
+            i.fa.fa-files-o
+          = link_to report_path(report), data: { confirm: t('are_you_sure') }, method: :delete, class: 'report-list-item__actions-link' do
+            i.fa.fa-trash-o
     .report-list-item-meta
       time.report-list-item-meta__updated-at(datetime="#{report.updated_at.to_datetime}" pubdate="pubdate")
         = l report.updated_at, format: :semi_long
@@ -21,7 +22,7 @@
           .report-list-item-meta__comment-count-label
             i.fa.fa-comment-o
           .report-list-item-meta__comment-count-value
-            = report.comments.count
+            = report.comments.size
       - if report.checks.any?
         .report-list-item-meta__comment-count
           .report-list-item-meta__comment-count-value
@@ -34,3 +35,6 @@
             = report.checks.last.created_at.strftime('%Y/%m/%d')
           .stamp__content.is-user-name
             = report.checks.last.user.login_name
+    - if search_words.present?
+     .report-list-item__body
+       = highlight(report.description, search_words)

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -1,74 +1,26 @@
-- if @search_word.present?
-  - title t('search_for', text: @search_word)
-  header.page-header
-    .container
-      .page-header__container
-        h2.page-header__title
-          = t('search_for', text: @search_word)
-        = link_to new_report_path, class: 'is-button-standard-md-warning' do
-          i.fa.fa-plus
-          = t('new_report')
-  .page-body
-    .container
-      = paginate @reports, position: "top"
-      - if @reports.nil? == false
-        .report-list
-          - @reports.each do |report|
-            - if report.present?
-              .report-list-item
-                .report-list-item__inner
-                  .report-list-item__author
-                    = gravatar_tag report.user, size: 44, html: { class: "report-list-item__author-icon"}
-                  header.report-list-item__header
-                    h2.report-list-item__title(itemprop="name")
-                      = link_to report, itempro: "url", class: "report-list-item__title-link" do
-                        = highlight("#{report.title}",@search_word.split(/ |　/))
-                    - if report.user == current_user
-                      .report-list-item__actions
-                        = link_to edit_report_path(report), class: 'report-list-item__actions-link' do
-                          i.fa.fa-pencil
-                        = link_to new_report_path(report), class: 'report-list-item__actions-link' do
-                          i.fa.fa-files-o
-                        = link_to report_path(report), data: { confirm: t('are_you_sure') }, method: :delete, class: 'report-list-item__actions-link' do
-                          i.fa.fa-trash-o
+- title @search_words.present? ? t('search_for', text: @search_words.join(' ')) : t('reports')
 
-                    .report-list-item-meta
-                      time.report-list-item-meta__updated-at(datetime="#{report.updated_at.to_datetime}" pubdate="pubdate")
-                        = l report.updated_at, format: :short
-                      - if report.comments.any?
-                        .report-list-item-meta__comments
-                          = t('report_comments_any')
-                          = report.comments.count
-                          = t('comments_count')
-                  .report-list-item__body
-                    = highlight("#{report.description}", @search_word.split(/ |　/))
-      = paginate @reports, position: "bottom"
+header.page-header.is-margin-bottom-0.has-border-bottom-none
+  .container
+    .page-header__container
+      h2.page-header__title= title
+      = link_to new_report_path, class: 'is-button-standard-md-warning' do
+        i.fa.fa-plus
+        = t('new_report')
 
-- else
-  - title t('reports')
-  header.page-header.is-margin-bottom-0.has-border-bottom-none
-    .container
-      .page-header__container
-        h1.page-header__title
-          = t('reports')
-        .page-header__action
-          = link_to new_report_path, class: 'is-button-standard-md-warning' do
-            i.fa.fa-plus
-            = t('new_report')
-  nav.sort-nav
-    .container
-      .sort-nav__inner
-        = form_tag reports_url, method: 'get' do
-          = label_tag :practice_id, 'プラクティスで絞り込む:', class: 'sort-nav__label'
-          .is-button-standard-sm-secondary.is-select.sort-nav__select
-            = select_tag :practice_id, options_from_collection_for_select(Practice.all, :id, :title, { selected: params[:practice_id] }), include_blank: '全ての日報を表示', onchange: "this.form.submit()"
+nav.sort-nav
+  .container
+    .sort-nav__inner
+      = form_tag reports_url, method: 'get' do
+        = hidden_field_tag :word, @search_words
+        = label_tag :practice_id, 'プラクティスで絞り込む:', class: 'sort-nav__label'
+        .is-button-standard-sm-secondary.is-select.sort-nav__select
+          = select_tag :practice_id, options_from_collection_for_select(Practice.all, :id, :title, { selected: params[:practice_id] }), include_blank: '全ての日報を表示', onchange: "this.form.submit()"
 
-  .page-body
-    .container
-      = paginate @reports, position: "top"
-      - if @reports.nil? == false
-        .report-list
-          - @reports.each do |report|
-            - if report.present?
-              = render 'report_list_item', report: report
-      = paginate @reports, position: "bottom"
+.page-body
+  .container
+    = paginate @reports, position: "top"
+    - if @reports.present?
+      .report-list
+        = render partial: 'reports/report_list_item', collection: @reports, as: :report, locals: { search_words: @search_words }
+    = paginate @reports, position: "bottom"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -526,7 +526,7 @@ ja:
   order: 並び順
   solved: 解決済み
   unsolved: 未解決
-  related-reports: このチュートリアルに関する日報
+  related-reports: このプラクティスに関する日報
   to_index_of_reports: 日報一覧へ
   to_index_of_questions: Q&A一覧へ
   post_comment: コメントを投稿


### PR DESCRIPTION
#### All

- [x] Fix N+1 problem in listing reports
- [x] Hide edit/delete/copy link if user does not own the report

#### Reports page (`/reports`)

- [x] Remove `set_reports` and `set_search_word`. It needs only `index` action
- [x] Fetch 25, which was default, reports in index and search. 30 reports in index or 15 reports in search was fetched before. I just unified them.
- [x] Filter reports by a practice even if there is a search word

##### Before

![before](https://user-images.githubusercontent.com/26753/32923737-824e2c54-cb7c-11e7-804e-b87623d18069.png)

##### After

![after](https://user-images.githubusercontent.com/26753/32923738-82768104-cb7c-11e7-8001-838bf2d70b5c.png)

#### Practice page (`/practices/xxxx`)

- [x] Remove `全てを見る` link. The page has already fetched all reports
- [x] Replace `チュートリアル` with `プラクティス`
- [x] Sort reports by `updated_at`

##### Before

![before2](https://user-images.githubusercontent.com/26753/32923749-8d7e4b2c-cb7c-11e7-863b-080933243571.png)

##### After

![after2](https://user-images.githubusercontent.com/26753/32923747-8d597090-cb7c-11e7-8a0e-4a824537b7a9.png)

Sorry, this PR is a little big..