### PR TITLE
ユーザー名のautocompleteをオフにした

### DIFF
--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -3,7 +3,7 @@
   .auth-form-items
     .auth-form-item
       = f.label :login_name, class: 'a-sm-label is-required'
-      = f.text_field :login_name, class: 'a-sm-text-input'
+      = f.text_field :login_name, class: 'a-sm-text-input', autocomplete: :off
       .auth-form-item__help
         p= t('login_name_description')
     .auth-form-item
@@ -44,10 +44,10 @@
       = f.text_field :feed_url, class: 'a-sm-text-input'
     .auth-form-item
       = f.label :password, class: 'a-sm-label'
-      = f.password_field :password, class: 'a-sm-text-input'
+      = f.password_field :password, class: 'a-sm-text-input', autocomplete: :off
     .auth-form-item
       = f.label :password_confirmation, class: 'a-sm-label'
-      = f.password_field :password_confirmation, class: 'a-sm-text-input'
+      = f.password_field :password_confirmation, class: 'a-sm-text-input', autocomplete: :off
     .auth-form-item
       = f.label :purpose, class: 'a-sm-label is-required'
       ul.auth-form-item__radio-buttons.is-half

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -3,7 +3,7 @@
   .auth-form-items
     .auth-form-item
       = f.label :login_name, class: 'a-sm-label is-required'
-      = f.text_field :login_name, class: 'a-sm-text-input'
+      = f.text_field :login_name, class: 'a-sm-text-input', autocomplete: :off
       .auth-form-item__help
         p= t('login_name_description')
     .auth-form-item
@@ -41,10 +41,10 @@
       = f.text_field :feed_url, class: 'a-sm-text-input'
     .auth-form-item
       = f.label :password, class: 'a-sm-label is-required'
-      = f.password_field :password, class: 'a-sm-text-input'
+      = f.password_field :password, class: 'a-sm-text-input', autocomplete: :off
     .auth-form-item
       = f.label :password_confirmation, class: 'a-sm-label is-required'
-      = f.password_field :password_confirmation, class: 'a-sm-text-input'
+      = f.password_field :password_confirmation, class: 'a-sm-text-input', autocomplete: :off
       .auth-form-item__help
         p
           | パスワードをもう一度入力


### PR DESCRIPTION
管理者が他人のプロフィールを変更するときにlogin_nameに
自分の名前が入っているので。